### PR TITLE
AITOOL-1711 Update web-fcm-demo repo with fcm v0.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1212,6 +1212,24 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
+    "@endemolshinegroup/cosmiconfig-typescript-loader": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@endemolshinegroup/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-3.0.2.tgz",
+      "integrity": "sha512-QRVtqJuS1mcT56oHpVegkKBlgtWjXw/gHNWO3eL9oyB5Sc7HBoc2OLG/nYpVfT/Jejvo3NUrD0Udk7XgoyDKkA==",
+      "requires": {
+        "lodash.get": "^4",
+        "make-error": "^1",
+        "ts-node": "^9",
+        "tslib": "^2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.2.tgz",
@@ -1245,14 +1263,41 @@
       }
     },
     "@getyoti/react-face-capture": {
-      "version": "0.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-0.1.0-beta.1.tgz",
-      "integrity": "sha512-rPjpOmTy1fbyXgl63p3Oc/gIxrhWTe6td240DdEPPFDz2ccmWiNFqm+pYnNi3b2MVatF9qTaMRuM+g9doWfnkg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-0.1.0.tgz",
+      "integrity": "sha512-ElNzta6FRXW4Dqj1QP/ry1S6HO0ydBiX8/sHiEgSyTWJQKnQiPkhK+IUm3mA8/Qjnbcmiu2Q4hpiooD8OKyKEw==",
       "requires": {
+        "@lingui/macro": "3.6.0",
+        "@lingui/react": "3.6.0",
         "@svgr/parcel-plugin-svgr": "5.1.0",
+        "babel-plugin-macros": "3.0.1",
         "classnames": "2.2.6",
         "face-api.js": "0.22.0",
         "react-webcam": "4.1.1"
+      },
+      "dependencies": {
+        "babel-plugin-macros": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.0.1.tgz",
+          "integrity": "sha512-CKt4+Oy9k2wiN+hT1uZzOw7d8zb1anbQpf7KLwaaXRCi/4pzKdFKHf7v5mvoPmjkmxshh7eKZQuRop06r5WP4w==",
+          "requires": {
+            "@babel/runtime": "^7.12.5",
+            "cosmiconfig": "^7.0.0",
+            "resolve": "^1.19.0"
+          }
+        },
+        "cosmiconfig": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        }
       }
     },
     "@hapi/address": {
@@ -1590,6 +1635,62 @@
         "@types/node": "*",
         "@types/yargs": "^15.0.0",
         "chalk": "^4.0.0"
+      }
+    },
+    "@lingui/conf": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@lingui/conf/-/conf-3.8.1.tgz",
+      "integrity": "sha512-2bbJ+8mKZtgKnARuhvPRMtvzDtc2KKkrXsZNvXJ/EpWeU/YtlrgOnheRE2zf89ImdsW2a9TqK8F5lDInKunjow==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
+        "chalk": "^4.1.0",
+        "cosmiconfig": "^7.0.0",
+        "jest-validate": "^26.5.2",
+        "lodash.get": "^4.4.2"
+      },
+      "dependencies": {
+        "cosmiconfig": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+          "requires": {
+            "@types/parse-json": "^4.0.0",
+            "import-fresh": "^3.2.1",
+            "parse-json": "^5.0.0",
+            "path-type": "^4.0.0",
+            "yaml": "^1.10.0"
+          }
+        }
+      }
+    },
+    "@lingui/core": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-3.8.1.tgz",
+      "integrity": "sha512-t/78WfTGKnpZRWmxwo/VyiG2Y8hGMZG6/KoB62Le12g8Qio/RMbhgioVlkoU4iu6l+r6icYsD+tmXB+sLNrGYQ==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "make-plural": "^6.2.2",
+        "messageformat-parser": "^4.1.3"
+      }
+    },
+    "@lingui/macro": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lingui/macro/-/macro-3.6.0.tgz",
+      "integrity": "sha512-FXkN4UTLfRV8ISgYmDqvS4cUUqZhnW7g3QJQGEklz+LLmBTzKLqPmRU8P4NeoO9uoQOPL1b7g3MfP5qHPQmtwg==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "@lingui/conf": "^3.6.0",
+        "ramda": "^0.27.1"
+      }
+    },
+    "@lingui/react": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lingui/react/-/react-3.6.0.tgz",
+      "integrity": "sha512-u7HKSOdxTyPmiHNf/FGRw6cAES6Vpz/zddLn/yQrX7zWh0Ehk56oAc+nz+2B5IHedsu3pcgwNtOXYJCIuQdQew==",
+      "requires": {
+        "@babel/runtime": "^7.11.2",
+        "@lingui/core": "^3.6.0"
       }
     },
     "@material-ui/core": {
@@ -2799,6 +2900,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+    },
+    "arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -4916,6 +5022,11 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -5520,6 +5631,11 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -9732,6 +9848,11 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -9826,6 +9947,16 @@
         "pify": "^4.0.1",
         "semver": "^5.6.0"
       }
+    },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+    },
+    "make-plural": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.2.2.tgz",
+      "integrity": "sha512-8iTuFioatnTTmb/YJjywkVIHLjcwkFD9Ms0JpxjEm9Mo8eQYkh1z+55dwv4yc1jQ8ftVBxWQbihvZL1DfzGGWA=="
     },
     "makeerror": {
       "version": "1.0.11",
@@ -9940,6 +10071,11 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+    },
+    "messageformat-parser": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/messageformat-parser/-/messageformat-parser-4.1.3.tgz",
+      "integrity": "sha512-2fU3XDCanRqeOCkn7R5zW5VQHWf+T3hH65SzuqRvjatBK7r4uyFa5mEX+k6F9Bd04LVM5G4/BHBTUJsOdW7uyg=="
     },
     "methods": {
       "version": "1.1.2",
@@ -12536,6 +12672,11 @@
       "requires": {
         "performance-now": "^2.1.0"
       }
+    },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -16231,6 +16372,19 @@
       "resolved": "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz",
       "integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA=="
     },
+    "ts-node": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
+      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "requires": {
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "source-map-support": "^0.5.17",
+        "yn": "3.1.1"
+      }
+    },
     "ts-pnp": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
@@ -18001,6 +18155,11 @@
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         }
       }
+    },
+    "yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "0.1.0-beta.1",
+    "@getyoti/react-face-capture": "0.1.0",
     "@material-ui/core": "^4.11.2",
     "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/App.js
+++ b/src/App.js
@@ -92,7 +92,6 @@ const App = () => {
               captureMethod="auto"
               onSuccess={onSuccess}
               onError={onError}
-              format="jpeg"
             />
           </div>
         ) : (


### PR DESCRIPTION
# Jira ticket: [AITOOL-1711](https://lampkicking.atlassian.net/browse/AITOOL-1711)

## Purpose/Approach

- Bump FCM package to `v0.1.0`
- Remove `jpeg` prop from FCM componet as it is the new default value

## Checklist

- [ ] has tests
- [x] code without warnings
- [x] code is clear and well/self-documented