### PR TITLE
AITOOL-2419: bump FCM version to 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1224,9 +1224,9 @@
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
         }
       }
     },
@@ -1263,9 +1263,9 @@
       }
     },
     "@getyoti/react-face-capture": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-0.3.0.tgz",
-      "integrity": "sha512-68wuyDKFatxzDIehorZW/JGXSKX71Y0hunqyYl5oCbiErOwHSRYTCEkDKvknll639jcH4MeALUbFJobnnM+SLA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-0.3.1.tgz",
+      "integrity": "sha512-TJn22QjnclF9pKhakj65W0G2p7vLPKUgw3gRvJtjHfjiBk/wxAF1QIx1q5oEhp8wSQzLiLYD+A/27UNtrHkMSA==",
       "requires": {
         "@lingui/macro": "3.6.0",
         "@lingui/react": "3.6.0",
@@ -1287,9 +1287,9 @@
           }
         },
         "cosmiconfig": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
           "requires": {
             "@types/parse-json": "^4.0.0",
             "import-fresh": "^3.2.1",
@@ -1638,9 +1638,9 @@
       }
     },
     "@lingui/conf": {
-      "version": "3.10.4",
-      "resolved": "https://registry.npmjs.org/@lingui/conf/-/conf-3.10.4.tgz",
-      "integrity": "sha512-ywAYoALnGa8GLuRaC6jW2FKkkPF6TQBUs2ACth8lKHjvJNz/Q3ZYKkK+hQj4iLODc5jaCophACrpNrZj1ef/tw==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@lingui/conf/-/conf-3.12.1.tgz",
+      "integrity": "sha512-asTFAUTf8zxYU+fI1MxggJD/o4BenT/rE4IJ/+ngaf1cbzBo71lXmhSYkIa8/vTZrdHDSuXGzIL43f1D9BF6YA==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "@endemolshinegroup/cosmiconfig-typescript-loader": "^3.0.2",
@@ -1651,9 +1651,9 @@
       },
       "dependencies": {
         "cosmiconfig": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-          "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+          "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
           "requires": {
             "@types/parse-json": "^4.0.0",
             "import-fresh": "^3.2.1",
@@ -1665,9 +1665,9 @@
       }
     },
     "@lingui/core": {
-      "version": "3.10.4",
-      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-3.10.4.tgz",
-      "integrity": "sha512-V9QKQ9PFMTPrGGz2PaeKHZcxFikQZzJbptyQbVFJdXaKhdE2RH6HhdK1PIziDHqp6ZWPthVIfVLURT3ku8eu5w==",
+      "version": "3.12.1",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-3.12.1.tgz",
+      "integrity": "sha512-MkZgkaaBcFtmUXdck9YNMTMTwCRogUif8Ll4Wyqz0re2Ydo7fdwGFBkacYjOc787R5/UmZr2F21OtPqSbaoaJg==",
       "requires": {
         "@babel/runtime": "^7.11.2",
         "make-plural": "^6.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "0.3.0",
+    "@getyoti/react-face-capture": "0.3.1",
     "@material-ui/core": "^4.11.2",
     "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.11.4",


### PR DESCRIPTION
### Description

Update the version of the FCM to v0.3.1

### References

### Testing

Now the resulting image should be cropped in landscape scenarios.

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
