### PR TITLE
AITOOL-2955: Fix responsive for small screens

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -38,6 +38,7 @@ const useStyles = makeStyles((theme) =>
     options: {
       display: "flex",
       flexDirection: "row",
+      flexWrap: "wrap",
       justifyContent: "space-around",
       marginTop: "15px",
       paddingTop: "15px",

--- a/src/App.js
+++ b/src/App.js
@@ -1,9 +1,9 @@
 import React, { useState } from "react";
-import FaceCapture, { CAPTURE_METHOD } from "@getyoti/react-face-capture";
+import FaceCapture from "@getyoti/react-face-capture";
 import "@getyoti/react-face-capture/index.css";
 import Container from "@material-ui/core/Container";
 import { createStyles, makeStyles } from "@material-ui/core/styles";
-import { Button, Zoom, CircularProgress } from "@material-ui/core";
+import { Button, Zoom, CircularProgress, Grid } from "@material-ui/core";
 import ReplayIcon from "@material-ui/icons/Replay";
 import { Api } from "./api/api";
 import RadioButtons from "./components/RadioButtons";
@@ -36,10 +36,6 @@ const useStyles = makeStyles((theme) =>
       overflow: "hidden",
     },
     options: {
-      display: "flex",
-      flexDirection: "row",
-      flexWrap: "wrap",
-      justifyContent: "space-around",
       marginTop: "15px",
       paddingTop: "15px",
       border: "2px solid",
@@ -124,16 +120,28 @@ const App = () => {
                 secure={secureFlag}
               />
             </div>
-            <div className={classes.options}>
-              <SecureField currentValue={secureFlag} onChange={setSecureFlag} />
 
-              <RadioButtons
-                label="Level of assurance"
-                currentValue={levelOfAssurance}
-                values={assuranceLevels}
-                onClick={onLevelOfAssuranceChange}
-              />
-            </div>
+            <Grid
+              container
+              spacing={1}
+              justifyContent={"space-evenly"}
+              className={classes.options}
+            >
+              <Grid item xs={8} sm={4}>
+                <SecureField
+                  currentValue={secureFlag}
+                  onChange={setSecureFlag}
+                />
+              </Grid>
+              <Grid item xs={8} sm={4}>
+                <RadioButtons
+                  label="Level of assurance"
+                  currentValue={levelOfAssurance}
+                  values={assuranceLevels}
+                  onClick={onLevelOfAssuranceChange}
+                />
+              </Grid>
+            </Grid>
           </div>
         ) : (
           <div className={classes.imgContainer}>


### PR DESCRIPTION
# Jira ticket: [AITOOL-2401](https://lampkicking.atlassian.net/browse/AITOOL-2401)

## Purpose
Avoid some fields from overlapping on small screens.

## Approach
Made the flexbox so it uses multiple rows when the space is too small.

## Screenshots

| **BEFORE**                                        | **AFTER**                                        |
| ------------------------------------------------- | ------------------------------------------------ |
| <img width="590" alt="Before IMG Preview" src="https://user-images.githubusercontent.com/68226973/167613791-0545220c-7686-48d8-8127-01494610dc52.png"> | <img width="590" alt="After IMG Preview" src="https://user-images.githubusercontent.com/68226973/167666313-cbada718-5a31-4526-9be0-7c0a6085bda6.png"> |

## Checklist

- [ ] has tests
- [x] code without warnings
- [x] code is clear and well/self-documented
