### PR TITLE
AITOOL-3862: Bump fcm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web-fcm-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@getyoti/react-face-capture": "1.1.0",
+        "@getyoti/react-face-capture": "1.2.0",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "@testing-library/jest-dom": "^5.16.1",
@@ -1994,9 +1994,9 @@
       "extraneous": true
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.1.0.tgz",
-      "integrity": "sha512-XM3r7rQjxTyU+S1RX2csbiRnnr9apWXwDJAT5hoDM5INzy9M6buDIZum/x/id6Tacjt3dc0ps86nUo+JiR/E0Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.2.0.tgz",
+      "integrity": "sha512-vAmZTn9Gu+MQc4oAt6sFfv77WDOk6AfF61MoqHqxPqPnQKyHU1YKj9LwtuzMZaOFOcDjbdhUvNrDWdjBzfLJjQ==",
       "dependencies": {
         "@lingui/macro": "3.6.0",
         "@lingui/react": "3.6.0",
@@ -18724,9 +18724,9 @@
       }
     },
     "@getyoti/react-face-capture": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.1.0.tgz",
-      "integrity": "sha512-XM3r7rQjxTyU+S1RX2csbiRnnr9apWXwDJAT5hoDM5INzy9M6buDIZum/x/id6Tacjt3dc0ps86nUo+JiR/E0Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.2.0.tgz",
+      "integrity": "sha512-vAmZTn9Gu+MQc4oAt6sFfv77WDOk6AfF61MoqHqxPqPnQKyHU1YKj9LwtuzMZaOFOcDjbdhUvNrDWdjBzfLJjQ==",
       "requires": {
         "@lingui/macro": "3.6.0",
         "@lingui/react": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "1.1.0",
+    "@getyoti/react-face-capture": "1.2.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
# [AITOOL-3862](https://lampkicking.atlassian.net/browse/AITOOL-3862)

## What?

Upgrade FCM version.

## Why?

Use the latest version for the FCM.