### PR TITLE
AITOOL 4187 - Bump FCM version to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web-fcm-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@getyoti/react-face-capture": "1.2.0",
+        "@getyoti/react-face-capture": "1.3.0",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "@testing-library/jest-dom": "^5.16.1",
@@ -1994,16 +1994,15 @@
       "extraneous": true
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.2.0.tgz",
-      "integrity": "sha512-vAmZTn9Gu+MQc4oAt6sFfv77WDOk6AfF61MoqHqxPqPnQKyHU1YKj9LwtuzMZaOFOcDjbdhUvNrDWdjBzfLJjQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.3.0.tgz",
+      "integrity": "sha512-f5kce87m15xuwf/UiAuMVPHUXjstQhUkKhZAtFctPMYi8SHQSg5Ak1FxXlQK7gb3JpWJsG/JJP2cpbsrfU0L6g==",
       "dependencies": {
         "@lingui/macro": "3.6.0",
         "@lingui/react": "3.6.0",
         "axios": "0.24.0",
         "classnames": "2.2.6",
-        "face-api.js": "0.22.0",
-        "react-resize-detector": "7.0.0"
+        "face-api.js": "0.22.0"
       },
       "peerDependencies": {
         "react": ">=16.12.0 <18",
@@ -3757,11 +3756,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.6.tgz",
       "integrity": "sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw=="
-    },
-    "node_modules/@types/resize-observer-browser": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
-      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg=="
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -13765,19 +13759,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-resize-detector": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.0.0.tgz",
-      "integrity": "sha512-Xd1POfpVzH9O3F/xB/0xYy2ijtKjE/z7y4c/aJP593YSzhPy2vDhsNPjes+uQbgL1RezxJajQ679qPs8K5LAFw==",
-      "dependencies": {
-        "@types/resize-observer-browser": "^0.1.6",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/react-scripts": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.0.tgz",
@@ -18724,16 +18705,15 @@
       }
     },
     "@getyoti/react-face-capture": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.2.0.tgz",
-      "integrity": "sha512-vAmZTn9Gu+MQc4oAt6sFfv77WDOk6AfF61MoqHqxPqPnQKyHU1YKj9LwtuzMZaOFOcDjbdhUvNrDWdjBzfLJjQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.3.0.tgz",
+      "integrity": "sha512-f5kce87m15xuwf/UiAuMVPHUXjstQhUkKhZAtFctPMYi8SHQSg5Ak1FxXlQK7gb3JpWJsG/JJP2cpbsrfU0L6g==",
       "requires": {
         "@lingui/macro": "3.6.0",
         "@lingui/react": "3.6.0",
         "axios": "0.24.0",
         "classnames": "2.2.6",
-        "face-api.js": "0.22.0",
-        "react-resize-detector": "7.0.0"
+        "face-api.js": "0.22.0"
       },
       "dependencies": {
         "axios": {
@@ -20046,11 +20026,6 @@
       "requires": {
         "@types/react": "*"
       }
-    },
-    "@types/resize-observer-browser": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.7.tgz",
-      "integrity": "sha512-G9eN0Sn0ii9PWQ3Vl72jDPgeJwRWhv2Qk/nQkJuWmRmOB4HX3/BhD5SE1dZs/hzPZL/WKnvF0RHdTSG54QJFyg=="
     },
     "@types/resolve": {
       "version": "1.17.1",
@@ -27514,15 +27489,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
-    },
-    "react-resize-detector": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.0.0.tgz",
-      "integrity": "sha512-Xd1POfpVzH9O3F/xB/0xYy2ijtKjE/z7y4c/aJP593YSzhPy2vDhsNPjes+uQbgL1RezxJajQ679qPs8K5LAFw==",
-      "requires": {
-        "@types/resize-observer-browser": "^0.1.6",
-        "lodash": "^4.17.21"
-      }
     },
     "react-scripts": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "1.2.0",
+    "@getyoti/react-face-capture": "1.3.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
# Jira ticket: [AITOOL-4187](https://lampkicking.atlassian.net/browse/AITOOL-4187)

## Purpose
Bump the FCM version to 1.3.0

## Screenshot
In this screenshot we can check the new error when a virtual camera is used.
<img width="823" alt="Screenshot 2023-03-17 at 09 14 49" src="https://user-images.githubusercontent.com/85619872/225850529-dc3273fe-76da-49fa-8310-7b761c2ac7dd.png">


[AITOOL-4187]: https://lampkicking.atlassian.net/browse/AITOOL-4187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ