### PR TITLE
AITOOL-4394: Bump FCM version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web-fcm-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@getyoti/react-face-capture": "1.3.0",
+        "@getyoti/react-face-capture": "1.4.0",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "@testing-library/jest-dom": "^5.16.1",
@@ -1994,9 +1994,9 @@
       "extraneous": true
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.3.0.tgz",
-      "integrity": "sha512-f5kce87m15xuwf/UiAuMVPHUXjstQhUkKhZAtFctPMYi8SHQSg5Ak1FxXlQK7gb3JpWJsG/JJP2cpbsrfU0L6g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.4.0.tgz",
+      "integrity": "sha512-TLE9xyfqQ4/oX/lr+UYy42ztXYT+w9qsaA6OtUaWiI8ICmjGm0cF5Y3EbQbcu39Ml6qYH3EAhALtKiszMq59tQ==",
       "dependencies": {
         "@lingui/macro": "3.6.0",
         "@lingui/react": "3.6.0",
@@ -18705,9 +18705,9 @@
       }
     },
     "@getyoti/react-face-capture": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.3.0.tgz",
-      "integrity": "sha512-f5kce87m15xuwf/UiAuMVPHUXjstQhUkKhZAtFctPMYi8SHQSg5Ak1FxXlQK7gb3JpWJsG/JJP2cpbsrfU0L6g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-1.4.0.tgz",
+      "integrity": "sha512-TLE9xyfqQ4/oX/lr+UYy42ztXYT+w9qsaA6OtUaWiI8ICmjGm0cF5Y3EbQbcu39Ml6qYH3EAhALtKiszMq59tQ==",
       "requires": {
         "@lingui/macro": "3.6.0",
         "@lingui/react": "3.6.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "1.3.0",
+    "@getyoti/react-face-capture": "1.4.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
# Jira ticket: [AITOOL-4394](https://lampkicking.atlassian.net/browse/AITOOL-4394)

## Purpose

Bump the FCM version to `1.4.0`.

[AITOOL-4394]: https://lampkicking.atlassian.net/browse/AITOOL-4394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ