### PR TITLE
AITOOL-5356: Update FCM to 2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web-fcm-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@getyoti/react-face-capture": "2.1.0",
+        "@getyoti/react-face-capture": "2.2.0",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "@testing-library/jest-dom": "^5.16.1",
@@ -2000,9 +2000,9 @@
       "extraneous": true
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.1.0.tgz",
-      "integrity": "sha512-1/mZuHBYAd7PjkphhuMOuCoYYnVwGOkYjpwfkYcZpvJaTQp/XFXmfSJuSPUPjpWVbYtFpHOnZpDwn6AhnzlUWA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.2.0.tgz",
+      "integrity": "sha512-ZPM2NpYex4U/hIBKBLbSJrd6voBH4rTroHXU4OkRAj4E+0ZTwkth6RkP4JhlSsAKpDAjRdmQSU0VVeZOK9iFPw==",
       "dependencies": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",
@@ -18920,9 +18920,9 @@
       }
     },
     "@getyoti/react-face-capture": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.1.0.tgz",
-      "integrity": "sha512-1/mZuHBYAd7PjkphhuMOuCoYYnVwGOkYjpwfkYcZpvJaTQp/XFXmfSJuSPUPjpWVbYtFpHOnZpDwn6AhnzlUWA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.2.0.tgz",
+      "integrity": "sha512-ZPM2NpYex4U/hIBKBLbSJrd6voBH4rTroHXU4OkRAj4E+0ZTwkth6RkP4JhlSsAKpDAjRdmQSU0VVeZOK9iFPw==",
       "requires": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "2.1.0",
+    "@getyoti/react-face-capture": "2.2.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
# Jira ticket: [AITOOL-5356](https://lampkicking.atlassian.net/browse/AITOOL-5356)

## Purpose

- Bump the FCM version to `2.2.0`.

[AITOOL-5356]: https://lampkicking.atlassian.net/browse/AITOOL-5356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ