### PR TITLE
AITOOL-5651: Update FCM to 2.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web-fcm-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@getyoti/react-face-capture": "2.2.0",
+        "@getyoti/react-face-capture": "2.2.1",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "@testing-library/jest-dom": "^5.16.1",
@@ -2509,9 +2509,9 @@
       "extraneous": true
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.2.0.tgz",
-      "integrity": "sha512-ZPM2NpYex4U/hIBKBLbSJrd6voBH4rTroHXU4OkRAj4E+0ZTwkth6RkP4JhlSsAKpDAjRdmQSU0VVeZOK9iFPw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.2.1.tgz",
+      "integrity": "sha512-QmiGI5CCPv5VqIzbbSUqLuV3EMYh01/Lq9x2h0vn6Wt/obaHp1g1c54Qx20FS9RKtdYn0ZnA07Ts/G3CYHqF+g==",
       "dependencies": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",
@@ -20478,9 +20478,9 @@
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g=="
     },
     "@getyoti/react-face-capture": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.2.0.tgz",
-      "integrity": "sha512-ZPM2NpYex4U/hIBKBLbSJrd6voBH4rTroHXU4OkRAj4E+0ZTwkth6RkP4JhlSsAKpDAjRdmQSU0VVeZOK9iFPw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.2.1.tgz",
+      "integrity": "sha512-QmiGI5CCPv5VqIzbbSUqLuV3EMYh01/Lq9x2h0vn6Wt/obaHp1g1c54Qx20FS9RKtdYn0ZnA07Ts/G3CYHqF+g==",
       "requires": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "2.2.0",
+    "@getyoti/react-face-capture": "2.2.1",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
# Jira ticket: [AITOOL-5651](https://lampkicking.atlassian.net/browse/AITOOL-5651)

## Purpose

Bump the FCM version to 2.2.1

![image](https://github.com/getyoti/web-fcm-demo/assets/68226973/299a3469-c946-4c52-8ee6-c75ca9636de3)


[AITOOL-5651]: https://lampkicking.atlassian.net/browse/AITOOL-5651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ