### PR TITLE
AITOOL 5657 - Fix container overlapping

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,15 +26,21 @@ const useStyles = makeStyles((theme) =>
       marginTop: theme.spacing(3),
     },
     scanContainer: {
-      width: "50vw",
+      width: "66vw",
       marginLeft: "auto",
       marginRight: "auto",
+      // Laptop view
+      '@media (min-width: 992px)': {
+        width: "50vw",
+      },
+      // Tablet view
+      '@media (min-width: 768px)': {
+        width: "57vw",
+      }
     },
     faceCaptureWrapper: {
       borderRadius: 20,
       overflow: "hidden",
-      paddingTop: "3vh",
-      paddingBottom: "3vh",
     },
     options: {
       marginTop: "15px",

--- a/src/App.js
+++ b/src/App.js
@@ -33,6 +33,8 @@ const useStyles = makeStyles((theme) =>
     faceCaptureWrapper: {
       borderRadius: 20,
       overflow: "hidden",
+      paddingTop: "3vh",
+      paddingBottom: "3vh",
     },
     options: {
       marginTop: "15px",


### PR DESCRIPTION
# [AITOOL-5657](https://lampkicking.atlassian.net/browse/AITOOL-5657)

## What?
Add a padding at the top and at the bottom to fix the overlapping of the main div.

The value is a relative measure (`viewheight`) to be as much generic as possible.

## Screenshots
**Mobile**
https://github.com/getyoti/web-fcm-demo/assets/85619872/57d6080e-f28d-4d62-a781-8439abf9fb28

**Laptop**
https://github.com/getyoti/web-fcm-demo/assets/85619872/ae323ee6-0b96-4dec-a78a-cf8cf4ad2787

The values have been gotten from the [scan](https://github.com/lampkicking/ai-tool-scan-web/blob/main/src/utils/_variables.scss).

[AITOOL-5657]: https://lampkicking.atlassian.net/browse/AITOOL-5657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ