### PR TITLE
AITOOL 5971 - Bump FCM version to 2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web-fcm-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@getyoti/react-face-capture": "2.3.0",
+        "@getyoti/react-face-capture": "2.3.1",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "@testing-library/jest-dom": "^5.16.1",
@@ -2509,9 +2509,9 @@
       "extraneous": true
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.3.0.tgz",
-      "integrity": "sha512-NL+krqiH0AJEwoiyj1ScjKm/A7oyNjABlQydc3NaSa6JuWnaZaOk9kLbcKCmhF5acfFvlQFPET3dUxx/dUr1Yw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.3.1.tgz",
+      "integrity": "sha512-PZIrz11FVV8Xw/MKhSQ0nqWhOXaxsfHnNo/dozesvDx7jru4yf8WPL7TZbpZAG1DBWiGqBGh40p+cg/5KWOs3g==",
       "dependencies": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",
@@ -20478,9 +20478,9 @@
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g=="
     },
     "@getyoti/react-face-capture": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.3.0.tgz",
-      "integrity": "sha512-NL+krqiH0AJEwoiyj1ScjKm/A7oyNjABlQydc3NaSa6JuWnaZaOk9kLbcKCmhF5acfFvlQFPET3dUxx/dUr1Yw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.3.1.tgz",
+      "integrity": "sha512-PZIrz11FVV8Xw/MKhSQ0nqWhOXaxsfHnNo/dozesvDx7jru4yf8WPL7TZbpZAG1DBWiGqBGh40p+cg/5KWOs3g==",
       "requires": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "2.3.0",
+    "@getyoti/react-face-capture": "2.3.1",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
# [AITOOL-5971](https://lampkicking.atlassian.net/browse/AITOOL-5971)

## What?
Bump the FCM version from `2.3.0` to `2.3.1`.

## Screenshots

<img width="1512" alt="Screenshot 2024-08-16 at 12 07 10" src="https://github.com/user-attachments/assets/d07013e9-6461-4528-8807-86e51a647fc2">

https://github.com/user-attachments/assets/eb31dc12-027a-4d3a-bd92-248ff0c68bfd



[AITOOL-5971]: https://lampkicking.atlassian.net/browse/AITOOL-5971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ