### PR TITLE
Update FCM to version 2.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web-fcm-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@getyoti/react-face-capture": "2.3.1",
+        "@getyoti/react-face-capture": "2.3.2",
         "@material-ui/core": "^4.12.3",
         "@material-ui/icons": "^4.11.2",
         "@testing-library/jest-dom": "^5.16.1",
@@ -2509,9 +2509,9 @@
       "extraneous": true
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.3.1.tgz",
-      "integrity": "sha512-PZIrz11FVV8Xw/MKhSQ0nqWhOXaxsfHnNo/dozesvDx7jru4yf8WPL7TZbpZAG1DBWiGqBGh40p+cg/5KWOs3g==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.3.2.tgz",
+      "integrity": "sha512-9dIr+CSO7+sBKy3op4RgoG4HkQie6USWqTWm/3q6VZCDCUYs2BSFPXrL12Ob8tADFdeeaJlQweWDy/RYCcvApA==",
       "dependencies": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",
@@ -20478,9 +20478,9 @@
       "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g=="
     },
     "@getyoti/react-face-capture": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.3.1.tgz",
-      "integrity": "sha512-PZIrz11FVV8Xw/MKhSQ0nqWhOXaxsfHnNo/dozesvDx7jru4yf8WPL7TZbpZAG1DBWiGqBGh40p+cg/5KWOs3g==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.3.2.tgz",
+      "integrity": "sha512-9dIr+CSO7+sBKy3op4RgoG4HkQie6USWqTWm/3q6VZCDCUYs2BSFPXrL12Ob8tADFdeeaJlQweWDy/RYCcvApA==",
       "requires": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "2.3.1",
+    "@getyoti/react-face-capture": "2.3.2",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@testing-library/jest-dom": "^5.16.1",


### PR DESCRIPTION
Bump the FCM to the latest version after [2.3.2 release ](https://www.npmjs.com/package/@getyoti/react-face-capture/v/2.3.2)