### PR TITLE
AITOOL-6554 - update Vite config to load env variables correctly

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -2,10 +2,12 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 import copy from "rollup-plugin-copy";
 import { fileURLToPath } from "url";
-import { defineConfig, normalizePath } from "vite";
+import { defineConfig, normalizePath, loadEnv } from "vite";
 import EnvironmentPlugin from 'vite-plugin-environment'
 
-const PORT = process.env.SERVER_PORT || 5000;
+const env = loadEnv('', __dirname, '')
+
+const PORT = env.SERVER_PORT || 5000;
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -33,6 +35,6 @@ export default defineConfig({
       ],
       hook: "buildStart",
     }),
-    EnvironmentPlugin(['SDK_ID', 'ENDPOINT', 'PEM_FILE_PATH', 'BASE_URL', 'SERVER_PORT']),
+    EnvironmentPlugin(['SDK_ID', 'ENDPOINT', 'PEM_FILE_PATH', 'BASE_URL']),
   ],
 });


### PR DESCRIPTION
# [AITOOL-XXXX](https://lampkicking.atlassian.net/browse/AITOOL-XXXX)

## What?
- update Vite config to load env variables correctly

## Why?
- turns out EnvironmentPlugin only exposes the environment variable to the app code and not to the Vite config file, so .env file needs to be loaded separately

## Screenshots
- N/A