### PR TITLE
AITOOL-6705: Update react-face-capture to 2.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web-fcm-demo",
       "version": "2.5.1",
       "dependencies": {
-        "@getyoti/react-face-capture": "2.5.1",
+        "@getyoti/react-face-capture": "2.6.0",
         "axios": "1.6.8",
         "classnames": "^2.5.1",
         "clsx": "^1.1.1",
@@ -906,10 +906,9 @@
       }
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.5.1.tgz",
-      "integrity": "sha512-KaDZ5l39GfA3Tbb5aiRMclEgZwicicGlymaWt0R12Su9afhU5nUdB10M2fS8pV1C4yH/3zDnV61YJA8XdgTEyQ==",
-      "license": "Yoti Face Capture Licence",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.6.0.tgz",
+      "integrity": "sha512-lzGmbSSgFVDbpaNYgIboVnSg37ENlb/pyefOXyROG/5P94ifsrxbqRGORKS5OIMCiaGSemMqQ0ZoNtZib9o9Vg==",
       "dependencies": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-fcm-demo",
-      "version": "2.5.1",
+      "version": "2.6.0",
       "dependencies": {
         "@getyoti/react-face-capture": "2.6.0",
         "axios": "1.6.8",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.5.1",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "2.5.1",
+    "@getyoti/react-face-capture": "2.6.0",
     "axios": "1.6.8",
     "classnames": "^2.5.1",
     "clsx": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "private": false,
   "dependencies": {
     "@getyoti/react-face-capture": "2.6.0",


### PR DESCRIPTION
# [AITOOL-6705](https://lampkicking.atlassian.net/browse/AITOOL-6705)

## What?
Update react-face-capture to 2.6.0

[AITOOL-6705]: https://lampkicking.atlassian.net/browse/AITOOL-6705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ