### PR TITLE
AITOOL 6810 - Bump FCM version to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-fcm-demo",
-      "version": "2.6.0",
+      "version": "2.6.1",
       "dependencies": {
-        "@getyoti/react-face-capture": "2.6.0",
+        "@getyoti/react-face-capture": "2.6.1",
         "axios": "1.6.8",
         "classnames": "^2.5.1",
         "clsx": "^1.1.1",
@@ -906,13 +906,14 @@
       }
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.6.0.tgz",
-      "integrity": "sha512-lzGmbSSgFVDbpaNYgIboVnSg37ENlb/pyefOXyROG/5P94ifsrxbqRGORKS5OIMCiaGSemMqQ0ZoNtZib9o9Vg==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.6.1.tgz",
+      "integrity": "sha512-AmmYKNo1Mn69liS5GKKxL73YYmCfstQ6x1Upo2cVBoeaOkJLfdwIkb+lL0pTiDieWA5vy0hch4avuD7XiFxkTw==",
+      "license": "Yoti Face Capture Licence",
       "dependencies": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",
-        "axios": "1.6.5",
+        "axios": "1.8.4",
         "classnames": "2.2.6",
         "face-api.js": "0.22.0",
         "prop-types": "15.7.2",
@@ -924,12 +925,12 @@
       }
     },
     "node_modules/@getyoti/react-face-capture/node_modules/axios": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.5.tgz",
-      "integrity": "sha512-Ii012v05KEVuUoFWmMW/UQv9aRIc3ZwkWDcM+h5Il8izZCtRVpDUfwpoFf7eOtajT3QiGR4yDUx7lPqHJULgbg==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.4",
+        "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "2.6.0",
+    "@getyoti/react-face-capture": "2.6.1",
     "axios": "1.6.8",
     "classnames": "^2.5.1",
     "clsx": "^1.1.1",


### PR DESCRIPTION
# [AITOOL-6810](https://lampkicking.atlassian.net/browse/AITOOL-6810)

## What?
Bump FCM version to 2.6.1.

## Why?

## Screenshots
![Screenshot 2025-04-30 at 16 46 55](https://github.com/user-attachments/assets/6c22524d-08bd-4d7c-8257-dc0620f657e8)


[AITOOL-6810]: https://lampkicking.atlassian.net/browse/AITOOL-6810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ