### PR TITLE
AITOOL-6890 - update sfcm version to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-fcm-demo",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "dependencies": {
         "@getyoti/react-face-capture": "2.6.2",
         "axios": "1.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "private": false,
   "dependencies": {
     "@getyoti/react-face-capture": "2.6.2",


### PR DESCRIPTION
# [AITOOL-6890](https://lampkicking.atlassian.net/browse/AITOOL-6890)

## What?
- update `@getyoti/react-face-capture` dependency to latest

## Why?
- latest version is available


[AITOOL-6890]: https://lampkicking.atlassian.net/browse/AITOOL-6890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ