### PR TITLE
AITOOL-7164: Bump FCM version to 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-fcm-demo",
-      "version": "2.6.2",
+      "version": "2.7.0",
       "dependencies": {
-        "@getyoti/react-face-capture": "2.6.2",
+        "@getyoti/react-face-capture": "2.7.0",
         "axios": "1.6.8",
         "classnames": "^2.5.1",
         "clsx": "^1.1.1",
@@ -907,10 +907,9 @@
       }
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.6.2.tgz",
-      "integrity": "sha512-RqW39pLgcYlMTsIHOmdOiMIPjr+mfiso6IBpzjIHHiCiwRdQzJylrvt65mund9rOA5LHzqPi4K/sV11Iqq8rFw==",
-      "license": "Yoti Face Capture Licence",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.7.0.tgz",
+      "integrity": "sha512-gvM10xs2IOQkYLDPBRyjb0VEKIppx1WoPJwJDNXqyMjOm+a/UQ0TULMLizWVINgGe/ycO6eYIetob8+qqgxYhA==",
       "dependencies": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.6.2",
+  "version": "2.7.0",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "2.6.2",
+    "@getyoti/react-face-capture": "2.7.0",
     "axios": "1.6.8",
     "classnames": "^2.5.1",
     "clsx": "^1.1.1",


### PR DESCRIPTION
# [AITOOL-7164](https://lampkicking.atlassian.net/browse/AITOOL-7164)

## What?
Bump FCM version to 2.7.0

## Why?
It just got released! https://www.npmjs.com/package/@getyoti/react-face-capture/v/2.7.0


[AITOOL-7164]: https://lampkicking.atlassian.net/browse/AITOOL-7164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ