### PR TITLE
AITOOL 7958 - Bump FCM to 2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-fcm-demo",
-      "version": "2.8.1",
+      "version": "2.9.0",
       "dependencies": {
-        "@getyoti/react-face-capture": "2.8.1",
+        "@getyoti/react-face-capture": "2.9.0",
         "body-parser": "2.2.2",
         "classnames": "2.5.1",
         "dotenv-flow": "4.1.0",
@@ -967,20 +967,21 @@
       }
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.8.1.tgz",
-      "integrity": "sha512-Kzcgl7YF+JOeCz6uf6OnDMLWjhPSsZkzqYr1DHu6Ssz1lP0IPJpBq0BSn9Mymq+p/kMdoJrB3mz46qVgGaJW3A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.9.0.tgz",
+      "integrity": "sha512-1GX75sbPx+eQyLJHYhXq+2IATAnHMFunJWW5/5ksIsD0403NX3uKKs07o/xEnS4mF0sIu8PVeglQktS+RkZUbg==",
       "dependencies": {
         "@lingui/react": "4.1.2",
         "@xstate/react": "3.2.2",
         "classnames": "2.2.6",
         "face-api.js": "0.22.0",
+        "normalize.css": "8.0.1",
         "prop-types": "15.7.2",
         "xstate": "4.37.2"
       },
       "peerDependencies": {
-        "react": ">=16.14.0 <18.2.0",
-        "react-dom": ">=16.14.0 <18.2.0"
+        "react": ">=16.14.0 <=18.3.1",
+        "react-dom": ">=16.14.0 <=18.3.1"
       }
     },
     "node_modules/@getyoti/react-face-capture/node_modules/classnames": {
@@ -5751,6 +5752,11 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
     "node_modules/object-assign": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.8.1",
+  "version": "2.9.0",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "2.8.1",
+    "@getyoti/react-face-capture": "2.9.0",
     "body-parser": "2.2.2",
     "classnames": "2.5.1",
     "dotenv-flow": "4.1.0",


### PR DESCRIPTION
# [AITOOL-7958](https://lampkicking.atlassian.net/browse/AITOOL-7958)

## What?
Bump the FCM to 2.9.0. Moreover, bump the app version to 2.9.0 too.

## Screenshots
<img width="526" height="631" alt="Screenshot 2026-03-26 at 17 11 36" src="https://github.com/user-attachments/assets/58019835-8fbf-4238-83b6-1e9a09a0e38e" />


[AITOOL-7958]: https://lampkicking.atlassian.net/browse/AITOOL-7958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ