### PR TITLE
AITOOL-8204: Bump version to 2.9.2

### DIFF
--- a/docs/FCM-CHANGELOG.md
+++ b/docs/FCM-CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v2.9.2
+
+### Fixes
+
+- Fixed a bug causing the FCM to sometimes freeze after taking the picture.
+
 ## v2.9.1
 
 ### New features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-fcm-demo",
-      "version": "2.9.1",
+      "version": "2.9.2",
       "dependencies": {
-        "@getyoti/react-face-capture": "2.9.1",
+        "@getyoti/react-face-capture": "2.9.2",
         "body-parser": "2.2.2",
         "classnames": "2.5.1",
         "dotenv-flow": "4.1.0",
@@ -967,9 +967,9 @@
       }
     },
     "node_modules/@getyoti/react-face-capture": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.9.1.tgz",
-      "integrity": "sha512-9CedcEuiErDdfNUGddFaQLM9FE8bzHqEk7doGRqkmvlh82qAfpbBn6Q3LP47xGFx5O/fnL5R5Z44zmwnDii2GQ==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@getyoti/react-face-capture/-/react-face-capture-2.9.2.tgz",
+      "integrity": "sha512-QVhLMIWVqL1TBLuE6RgKxzuaSC2VQzwZeYTJTsh9xR9PLdTT8V47FDS6E4F8mzh6COGmPefDcMuhF/YZ7gVlPQ==",
       "license": "Yoti Face Capture Licence",
       "dependencies": {
         "@lingui/react": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "web-fcm-demo",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "private": false,
   "dependencies": {
-    "@getyoti/react-face-capture": "2.9.1",
+    "@getyoti/react-face-capture": "2.9.2",
     "body-parser": "2.2.2",
     "classnames": "2.5.1",
     "dotenv-flow": "4.1.0",


### PR DESCRIPTION
# [AITOOL-8204](https://lampkicking.atlassian.net/browse/AITOOL-8204)

## What?
Bump version to 2.9.2 and update changelog.

## Why?
To keep the demo up to date.

[AITOOL-8204]: https://lampkicking.atlassian.net/browse/AITOOL-8204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ